### PR TITLE
Implement generics for HandlingResults

### DIFF
--- a/src/main/java/com/bellotapps/utils/error_handler/ErrorHandler.java
+++ b/src/main/java/com/bellotapps/utils/error_handler/ErrorHandler.java
@@ -17,15 +17,18 @@ public interface ErrorHandler {
      *
      * @param exception The {@link Throwable} to be handled.
      * @param <T>       The concrete subclass type of {@link Throwable}.
+     * @param <E>       Concrete type of entity to be sent in the response.
      * @return a {@link HandlingResult} with the data to be returned to the API consumer.
      */
-    <T extends Throwable> HandlingResult handle(T exception);
+    <T extends Throwable, E> HandlingResult<E> handle(T exception);
 
 
     /**
      * Container class holding the results of handling a {@link Throwable}.
+     *
+     * @param <E> Concrete type of entity to be sent in the response.
      */
-    final class HandlingResult {
+    final class HandlingResult<E> {
 
         /**
          * The HTTP status code that must be returned in the response.
@@ -35,7 +38,7 @@ public interface ErrorHandler {
         /**
          * The entity that will be returned in the response. Can be null.
          */
-        private final Object errorRepresentationEntity;
+        private final E errorRepresentationEntity;
 
 
         /**
@@ -44,7 +47,7 @@ public interface ErrorHandler {
          * @param httpErrorCode             The HTTP status code that must be returned in the response.
          * @param errorRepresentationEntity The entity that will be returned in the response. Can be null.
          */
-        public HandlingResult(int httpErrorCode, Object errorRepresentationEntity) {
+        public HandlingResult(int httpErrorCode, E errorRepresentationEntity) {
             this.httpErrorCode = httpErrorCode;
             this.errorRepresentationEntity = errorRepresentationEntity;
         }
@@ -59,7 +62,7 @@ public interface ErrorHandler {
         /**
          * @return The entity that will be returned in the response. Can be null.
          */
-        public Object getErrorRepresentationEntity() {
+        public E getErrorRepresentationEntity() {
             return errorRepresentationEntity;
         }
     }

--- a/src/main/java/com/bellotapps/utils/error_handler/ErrorHandlerFactory.java
+++ b/src/main/java/com/bellotapps/utils/error_handler/ErrorHandlerFactory.java
@@ -59,7 +59,7 @@ public class ErrorHandlerFactory {
     /**
      * A {@link Map} holding cached {@link ExceptionHandler}s for a given package name.
      */
-    private final Map<String, List<ExceptionHandler<? extends Throwable>>> cachedHandlers;
+    private final Map<String, List<ExceptionHandler<? extends Throwable, ?>>> cachedHandlers;
 
 
     /**
@@ -127,7 +127,7 @@ public class ErrorHandlerFactory {
      */
     public ErrorHandler createErrorHandler(Collection<String> packages) {
         // Perform package scanning for those not cached
-        final Map<String, List<ExceptionHandler<? extends Throwable>>> foundedHandlers = packages.stream()
+        final Map<String, List<ExceptionHandler<? extends Throwable, ?>>> foundedHandlers = packages.stream()
                 .filter(pkg -> !cachedHandlers.containsKey(pkg))
                 .collect(Collectors.toMap(Function.identity(),
                         pkg -> scanPackage(pkg)
@@ -138,7 +138,7 @@ public class ErrorHandlerFactory {
         // Save in cache those handlers that have been found
         this.cachedHandlers.putAll(foundedHandlers);
         // Get stored handlers
-        final List<ExceptionHandler<? extends Throwable>> handlers = cachedHandlers.values()
+        final List<ExceptionHandler<? extends Throwable, ?>> handlers = cachedHandlers.values()
                 .stream()
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
@@ -168,7 +168,7 @@ public class ErrorHandlerFactory {
      *
      * @param <T> The concrete type of {@link ExceptionHandler}.
      */
-    private final static class ExceptionHandlerGetter<T extends ExceptionHandler<? extends Throwable>> {
+    private final static class ExceptionHandlerGetter<T extends ExceptionHandler<? extends Throwable, ?>> {
 
         /**
          * The class of {@link ExceptionHandler} extension.
@@ -273,7 +273,7 @@ public class ErrorHandlerFactory {
          *
          * @param handlerClass The class of the bean that has been found.
          */
-        private static void logBeanFound(Class<? extends ExceptionHandler<? extends Throwable>> handlerClass) {
+        private static void logBeanFound(Class<? extends ExceptionHandler<? extends Throwable, ?>> handlerClass) {
             @SuppressWarnings("unchecked") final Class<? extends Throwable> throwableClass =
                     (Class<? extends Throwable>) ResolvableType.forClass(ExceptionHandler.class, handlerClass)
                             .getGeneric(0)
@@ -286,7 +286,7 @@ public class ErrorHandlerFactory {
          *
          * @param handlerClass The class of the beans that has been found.
          */
-        private static void logMultipleBeans(Class<? extends ExceptionHandler<? extends Throwable>> handlerClass) {
+        private static void logMultipleBeans(Class<? extends ExceptionHandler<? extends Throwable, ?>> handlerClass) {
             LOGGER.warn("More than one bean exist for class {}. Will instantiate own handler", handlerClass);
         }
 
@@ -295,7 +295,7 @@ public class ErrorHandlerFactory {
          *
          * @param handlerClass The class of the not found beans.
          */
-        private static void logNoBeanFound(Class<? extends ExceptionHandler<? extends Throwable>> handlerClass) {
+        private static void logNoBeanFound(Class<? extends ExceptionHandler<? extends Throwable, ?>> handlerClass) {
             LOGGER.debug("No bean for class {}. Will create one", handlerClass);
         }
 
@@ -305,7 +305,7 @@ public class ErrorHandlerFactory {
          *
          * @param handlerClass The class of the bean that could not be gotten due to errors.
          */
-        private static void logBeansException(Class<? extends ExceptionHandler<? extends Throwable>> handlerClass) {
+        private static void logBeansException(Class<? extends ExceptionHandler<? extends Throwable, ?>> handlerClass) {
             LOGGER.error("Could not get bean for class {}", handlerClass);
 
         }

--- a/src/main/java/com/bellotapps/utils/error_handler/ExceptionHandler.java
+++ b/src/main/java/com/bellotapps/utils/error_handler/ExceptionHandler.java
@@ -7,13 +7,14 @@ package com.bellotapps.utils.error_handler;
  * {@link ExceptionHandlerObject}.
  *
  * @param <T> The concrete type of {@link Throwable} that will be handled by the object implementing this interface.
+ * @param <E> The concrete type of entity being sent in the handling result.
  * @author Juan Marcos Bellini
  * @see ExceptionHandlerObject
  * @see ErrorHandler
  * @see EnableErrorHandler
  */
 @FunctionalInterface
-public interface ExceptionHandler<T extends Throwable> {
+public interface ExceptionHandler<T extends Throwable, E> {
 
     /**
      * Handles the given {@code exception}.
@@ -21,5 +22,5 @@ public interface ExceptionHandler<T extends Throwable> {
      * @param exception The exception to be handled.
      * @return The {@link ErrorHandler.HandlingResult} of handling the given {@code exception}.
      */
-    ErrorHandler.HandlingResult handle(T exception);
+    ErrorHandler.HandlingResult<E> handle(T exception);
 }

--- a/src/test/java/com/bellotapps/utils/error_handler/ErrorHandlerImplTest.java
+++ b/src/test/java/com/bellotapps/utils/error_handler/ErrorHandlerImplTest.java
@@ -24,16 +24,16 @@ public class ErrorHandlerImplTest {
 
     @Test
     public void testListOfHandlersWithDefault() {
-        final ExceptionHandler<NullPointerException> nullPointerExceptionHandler =
+        final ExceptionHandler<NullPointerException, String> nullPointerExceptionHandler =
                 new TestingExceptionHandlers.NullPointerExceptionHandler();
-        final ExceptionHandler<IllegalArgumentException> illegalArgumentHandler =
+        final ExceptionHandler<IllegalArgumentException, String> illegalArgumentHandler =
                 new TestingExceptionHandlers.IllegalArgumentExceptionHandler();
-        final ExceptionHandler<RuntimeException> runtimeExceptionHandler =
+        final ExceptionHandler<RuntimeException, String> runtimeExceptionHandler =
                 new TestingExceptionHandlers.RuntimeExceptionHandler();
-        final ExceptionHandler<Throwable> throwableHandler =
+        final ExceptionHandler<Throwable, String> throwableHandler =
                 new TestingExceptionHandlers.ThrowableHandler();
 
-        final List<ExceptionHandler<? extends Throwable>> handlers = Stream
+        final List<ExceptionHandler<? extends Throwable, ?>> handlers = Stream
                 .of(nullPointerExceptionHandler, illegalArgumentHandler, runtimeExceptionHandler, throwableHandler)
                 .collect(Collectors.toList());
 
@@ -53,14 +53,14 @@ public class ErrorHandlerImplTest {
 
     @Test
     public void testListOfHandlersWithoutDefault() throws NoSuchFieldException, IllegalAccessException {
-        final ExceptionHandler<NullPointerException> nullPointerExceptionHandler =
+        final ExceptionHandler<NullPointerException, String> nullPointerExceptionHandler =
                 new TestingExceptionHandlers.NullPointerExceptionHandler();
-        final ExceptionHandler<IllegalArgumentException> illegalArgumentHandler =
+        final ExceptionHandler<IllegalArgumentException, String> illegalArgumentHandler =
                 new TestingExceptionHandlers.IllegalArgumentExceptionHandler();
-        final ExceptionHandler<RuntimeException> runtimeExceptionHandler =
+        final ExceptionHandler<RuntimeException, String> runtimeExceptionHandler =
                 new TestingExceptionHandlers.RuntimeExceptionHandler();
 
-        final List<ExceptionHandler<? extends Throwable>> handlers =
+        final List<ExceptionHandler<? extends Throwable, ?>> handlers =
                 Stream.of(nullPointerExceptionHandler, illegalArgumentHandler, runtimeExceptionHandler)
                         .collect(Collectors.toList());
 
@@ -96,12 +96,12 @@ public class ErrorHandlerImplTest {
      * @throws NoSuchFieldException   Never.
      * @throws IllegalAccessException Never.
      */
-    private static ExceptionHandler<Throwable> getDefaultHandler(ErrorHandlerImpl errorHandler)
+    private static ExceptionHandler<Throwable, String> getDefaultHandler(ErrorHandlerImpl errorHandler)
             throws NoSuchFieldException, IllegalAccessException {
         final Field defaultHandlerField = errorHandler.getClass().getDeclaredField("DEFAULT_THROWABLE_HANDLER");
         defaultHandlerField.setAccessible(true);
-        @SuppressWarnings("unchecked") final ExceptionHandler<Throwable> defaultHandler =
-                (ExceptionHandler<Throwable>) defaultHandlerField.get(errorHandler);
+        @SuppressWarnings("unchecked") final ExceptionHandler<Throwable, String> defaultHandler =
+                (ExceptionHandler<Throwable, String>) defaultHandlerField.get(errorHandler);
         defaultHandlerField.setAccessible(false);
 
         return defaultHandler;
@@ -117,8 +117,8 @@ public class ErrorHandlerImplTest {
      *                         the same way the {@link ErrorHandler}.
      * @param <T>              The concrete subtype of {@link Throwable}.
      */
-    private static <T extends Throwable> void testHandle(T throwable, ErrorHandler errorHandler,
-                                                         ExceptionHandler<T> throwableHandler, String errorMessage) {
+    private static <T extends Throwable, E> void testHandle(T throwable, ErrorHandler errorHandler,
+                                                         ExceptionHandler<T, E> throwableHandler, String errorMessage) {
         final ErrorHandler.HandlingResult errorHandlerResult = errorHandler.handle(throwable);
         final ErrorHandler.HandlingResult exceptionHandlerResult = throwableHandler.handle(throwable);
         // Test a result is returned

--- a/src/test/java/com/bellotapps/utils/error_handler/TestingExceptionHandlers.java
+++ b/src/test/java/com/bellotapps/utils/error_handler/TestingExceptionHandlers.java
@@ -5,35 +5,39 @@ package com.bellotapps.utils.error_handler;
  */
 /* package */ class TestingExceptionHandlers {
 
-    /* package */ static class NullPointerExceptionHandler implements ExceptionHandler<NullPointerException> {
+    /* package */ static class NullPointerExceptionHandler
+            implements ExceptionHandler<NullPointerException, String> {
 
         @Override
-        public ErrorHandler.HandlingResult handle(NullPointerException exception) {
-            return new ErrorHandler.HandlingResult(400, "Was null");
+        public ErrorHandler.HandlingResult<String> handle(NullPointerException exception) {
+            return new ErrorHandler.HandlingResult<>(400, "Was null");
         }
     }
 
-    /* package */ static class IllegalArgumentExceptionHandler implements ExceptionHandler<IllegalArgumentException> {
+    /* package */ static class IllegalArgumentExceptionHandler
+            implements ExceptionHandler<IllegalArgumentException, String> {
 
         @Override
-        public ErrorHandler.HandlingResult handle(IllegalArgumentException exception) {
-            return new ErrorHandler.HandlingResult(400, "illegal argument");
+        public ErrorHandler.HandlingResult<String> handle(IllegalArgumentException exception) {
+            return new ErrorHandler.HandlingResult<>(400, "illegal argument");
         }
     }
 
-    /* package */ static class RuntimeExceptionHandler implements ExceptionHandler<RuntimeException> {
+    /* package */ static class RuntimeExceptionHandler
+            implements ExceptionHandler<RuntimeException, String> {
 
         @Override
-        public ErrorHandler.HandlingResult handle(RuntimeException exception) {
-            return new ErrorHandler.HandlingResult(500, "runtime exception");
+        public ErrorHandler.HandlingResult<String> handle(RuntimeException exception) {
+            return new ErrorHandler.HandlingResult<>(500, "runtime exception");
         }
     }
 
-    /* package */ static class ThrowableHandler implements ExceptionHandler<Throwable> {
+    /* package */ static class ThrowableHandler
+            implements ExceptionHandler<Throwable, String> {
 
         @Override
-        public ErrorHandler.HandlingResult handle(Throwable exception) {
-            return new ErrorHandler.HandlingResult(500, "a throwable was not caught");
+        public ErrorHandler.HandlingResult<String> handle(Throwable exception) {
+            return new ErrorHandler.HandlingResult<>(500, "a throwable was not caught");
         }
     }
 }


### PR DESCRIPTION
- This allows the exception handlers have a more type-safe way of handling exceptions

Close #40 